### PR TITLE
Add module support to MappedReducer only

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -71,6 +71,13 @@ const reducer = new MappedReducer<State, ActionTypes>()
   // Invalid Action Types
   // .set('UNWELCOMMED', plusSubReducer)
 
+  // If you want to use the MappedReducer as part of a module setup, you can just pass it an opts object
+  // with initialState as your initial state.
+  // new MappedReducer<State, ActionTypes>({ initialState })
+
+  // Then intialize your store like a module;
+  // createStore(combineReducers<State>({ count: reducer.reduce }))
+
 // Reducer has a reduce method, `reducer.reduce`. Just pass it to our store!
 const store = createStore(reducer.reduce, initialState)
 

--- a/src/lib/mapped-pipe-reducer.ts
+++ b/src/lib/mapped-pipe-reducer.ts
@@ -1,11 +1,18 @@
 import {
   Action,
+  MappedReducerOptions,
   Reducer,
 } from './types'
 
 type ReducerArray<STATE, ACTION> = Reducer<STATE, ACTION>[]
 export class MappedPipeReducer<STATE, ACTION_TYPE = any, ACTION extends Action = Action> {
+  private initialState: STATE
+
   private reducerMap = new Map<ACTION_TYPE, ReducerArray<STATE, Action>>()
+
+  constructor(opts: MappedReducerOptions<STATE> = {}) {
+    this.initialState = opts.initialState
+  }
 
   /**
    * Append reducer functions for the given key
@@ -52,7 +59,7 @@ export class MappedPipeReducer<STATE, ACTION_TYPE = any, ACTION extends Action =
 
   public get = <SETTED_ACTION_TYPE extends ACTION_TYPE>(actionType: SETTED_ACTION_TYPE) => this.reducerMap.get(actionType)
 
-  public reduce = (state: STATE, action: ACTION): STATE => {
+  public reduce = (state: STATE = this.initialState, action: ACTION): STATE => {
     if (!this.reducerMap.has(action.type)) return state
     const reducers = this.reducerMap.get(action.type)
     return reducers.reduce((aState, reducer) => reducer(aState, action), state)

--- a/src/lib/mapped-reducer.ts
+++ b/src/lib/mapped-reducer.ts
@@ -1,10 +1,17 @@
 import {
   Action,
+  MappedReducerOptions,
   Reducer,
 } from './types'
 
 export class MappedReducer<STATE, ACTION_TYPE = any, ACTION extends Action = Action> {
+  private initialState: STATE
+
   private reducerMap = new Map<ACTION_TYPE, Reducer<STATE, Action>>()
+
+  constructor(opts: MappedReducerOptions<STATE> = {}) {
+    this.initialState = opts.initialState
+  }
 
   public set = <SETTED_ACTION extends ACTION, SETTED_ACTION_TYPE extends SETTED_ACTION['type'] & ACTION_TYPE>(
     actionTypeOrActionTypes: SETTED_ACTION_TYPE | SETTED_ACTION_TYPE[],
@@ -21,7 +28,7 @@ export class MappedReducer<STATE, ACTION_TYPE = any, ACTION extends Action = Act
 
   public get = <SETTED_ACTION_TYPE extends ACTION_TYPE>(actionType: SETTED_ACTION_TYPE) => this.reducerMap.get(actionType)
 
-  public reduce = (state: STATE, action: ACTION): STATE => {
+  public reduce = (state: STATE = this.initialState, action: ACTION): STATE => {
     if (!this.reducerMap.has(action.type)) return state
     return this.reducerMap.get(action.type)(state, action)
   }

--- a/src/lib/mapped-unique-pipe-reducer.ts
+++ b/src/lib/mapped-unique-pipe-reducer.ts
@@ -1,5 +1,6 @@
 import {
   Action,
+  MappedReducerOptions,
   Reducer,
 } from './types'
 
@@ -10,7 +11,13 @@ type ReducerSet<STATE, ACTION> = Set<Reducer<STATE, ACTION>>
  * By using Set, we can ensure our reducer is set ONLY ONCE.
  */
 export class MappedUniquePipeReducer<STATE, ACTION_TYPE = any, ACTION extends Action = Action> {
+  private initialState: STATE
+
   private reducerMap = new Map<ACTION_TYPE, ReducerSet<STATE, Action>>()
+
+  constructor(opts: MappedReducerOptions<STATE> = {}) {
+    this.initialState = opts.initialState
+  }
 
   /**
    * Append reducer functions for the given key
@@ -58,7 +65,7 @@ export class MappedUniquePipeReducer<STATE, ACTION_TYPE = any, ACTION extends Ac
 
   public get = <SETTED_ACTION_TYPE extends ACTION_TYPE>(actionType: SETTED_ACTION_TYPE) => Array.from(this.reducerMap.get(actionType))
 
-  public reduce = (state: STATE, action: ACTION): STATE => {
+  public reduce = (state: STATE = this.initialState, action: ACTION): STATE => {
     if (!this.reducerMap.has(action.type)) return state
     const reducers = Array.from(this.reducerMap.get(action.type))
     return reducers.reduce((aState, reducer) => reducer(aState, action), state)

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -11,4 +11,7 @@ export interface PayloadAction <ACTION_TYPE, PAYLOAD> extends Redux.Action {
 
 export type Action = PureAction<any> | PayloadAction<any, any>
 
+export interface MappedReducerOptions<S> {
+  initialState?: S
+}
 export type Reducer<STATE, ACTION> = (state: STATE, action: ACTION) => STATE


### PR DESCRIPTION
I added support for the MappedReducer to have initial state when you want to use it as part of a module structure.

The MappedPipeReducers still need to be done. @Rokt33r can you assist in this?